### PR TITLE
feat(utils): Adds site hostname to backup success email

### DIFF
--- a/offsite_backups/offsite_backups/offsite_backup_utils.py
+++ b/offsite_backups/offsite_backups/offsite_backup_utils.py
@@ -5,7 +5,7 @@ import glob
 import os
 
 import frappe
-from frappe.utils import cint, split_emails
+from frappe.utils import cint, get_host_name, split_emails
 
 
 def send_email(success, service_name, doctype, email_field, error_status=None):
@@ -24,8 +24,8 @@ def send_email(success, service_name, doctype, email_field, error_status=None):
 		subject = "Backup Upload Successful"
 		message = """
 <h3>Backup Uploaded Successfully!</h3>
-<p>Hi there, this is just to inform you that your backup was successfully uploaded to your {} bucket. So relax!</p>""".format(
-			service_name
+<p>Hi there, this is just to inform you that the backup of your site {} was successfully uploaded to your {} bucket. So relax!</p>""".format(
+			get_host_name(), service_name
 		)
 	else:
 		subject = "[Warning] Backup Upload Failed"


### PR DESCRIPTION
closes #5

This PR adds host name to success email text.
The issue also requires to add Company name, but IMO it is irrelevant as the backup taken is for the entire site and not only for one company
