### PR TITLE
fix: call take_backup instead of take_backups_s3 from JS to ensure async execution

### DIFF
--- a/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.js
+++ b/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.js
@@ -12,15 +12,21 @@ frappe.ui.form.on("S3 Backup Settings", {
 			frm.add_custom_button(__("Take Backup Now"), function () {
 				frm.dashboard.set_headline_alert("S3 Backup Started!");
 				frappe.call({
-					method: "offsite_backups.offsite_backups.doctype.s3_backup_settings.s3_backup_settings.take_backups_s3",
+					method: "frappe.integrations.doctype.s3_backup_settings.s3_backup_settings.take_backup",
 					callback: function (r) {
-						if (!r.exc) {
-							frappe.msgprint(__("S3 Backup complete!"));
+						if (!r.exc && r.message) {
+							const job_id = r.message;
+							frappe.msgprint({
+								message: __(
+									"S3 Backup has been queued. You can track the progress <a href='/app/rq-job/{0}' target='_blank'>here</a>.",
+									[job_id]
+								),
+							});
 							frm.dashboard.clear_headline();
 						}
 					},
 				});
-			}).addClass("btn-primary");
+			});
 		}
 	},
 });

--- a/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
@@ -78,12 +78,12 @@ class S3BackupSettings(Document):
 @frappe.whitelist()
 def take_backup():
 	"""Enqueue longjob for taking backup to s3"""
-	enqueue(
-		"offsite_backups.offsite_backups.doctype.s3_backup_settings.s3_backup_settings.take_backups_s3",
+	job = enqueue(
+		"frappe.integrations.doctype.s3_backup_settings.s3_backup_settings.take_backups_s3",
 		queue="long",
 		timeout=1500,
 	)
-	frappe.msgprint(_("Queued for backup. It may take a few minutes to an hour."))
+	return job.id
 
 
 def take_backups_daily():


### PR DESCRIPTION
## Problem
The JS form was calling `take_backups_s3` directly via `frappe.call`, which runs 
the backup synchronously within the HTTP request. This causes a request timeout 
for large backups since the connection is held open until the backup completes.