### PR TITLE
fix: reconnect to DB after long backup upload in Google Drive integra…

### DIFF
--- a/offsite_backups/offsite_backups/doctype/google_drive/google_drive.py
+++ b/offsite_backups/offsite_backups/doctype/google_drive/google_drive.py
@@ -203,10 +203,13 @@ def upload_system_backup_to_google_drive():
 			send_email(False, "Google Drive", "Google Drive", "email", error_status=e)
 
 	set_progress(3, _("Uploading successful."))
-	frappe.db.set_single_value("Google Drive", "last_backup_on", frappe.utils.now_datetime())
+	try:
+		frappe.db.set_single_value("Google Drive", "last_backup_on", frappe.utils.now_datetime())
+	except Exception:
+		frappe.db.connect()
+		frappe.db.set_single_value("Google Drive", "last_backup_on", frappe.utils.now_datetime())
 	send_email(True, "Google Drive", "Google Drive", "email")
 	return _("Google Drive Backup Successful.")
-
 
 def daily_backup():
 	drive_settings = frappe.db.get_singles_dict("Google Drive", cast=True)


### PR DESCRIPTION
Closes #17

### Problem

`upload_system_backup_to_google_drive()` runs `mysqldump` as a subprocess and uploads large files to Google Drive. Both operations take significant time with zero DB activity.

MySQL's `wait_timeout` kills the idle connection.

When the function reaches  
`frappe.db.set_single_value("Google Drive", "last_backup_on", ...)`,  
the write fails on the dead connection.

This causes `last_backup_on` to never update even though backups reach Google Drive successfully.

### Fix

Wrap the `set_single_value` call in a try/except that reconnects on failure:

```python
try:
    frappe.db.set_single_value("Google Drive", "last_backup_on", frappe.utils.now_datetime())
except Exception:
    frappe.db.connect()
    frappe.db.set_single_value("Google Drive", "last_backup_on", frappe.utils.now_datetime())
```

### Testing

Tested with a `4.4 GB` database backup file.

Without the fix, the RQ job fails with `InterfaceError(0, '')`.

With the fix, `last_backup_on` updates correctly after a `51-minute` job (well beyond MySQL's `600s`/`1500` `wait_timeout`).