### PR TITLE
feat(s3-backup-settings): add backup rotation to automatically delete old S3 backups

### DIFF
--- a/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.json
+++ b/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "creation": "2017-09-04 20:57:20.129205",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -21,7 +22,10 @@
   "backup_path",
   "backup_details_section",
   "frequency",
-  "backup_files"
+  "backup_files",
+  "column_break_epci",
+  "enable_backup_rotation",
+  "retention_count"
  ],
  "fields": [
   {
@@ -132,12 +136,31 @@
    "fieldname": "backup_path",
    "fieldtype": "Data",
    "label": "Backup Path"
+  },
+  {
+   "fieldname": "column_break_epci",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_backup_rotation",
+   "fieldtype": "Check",
+   "label": "Enable Backup Rotation"
+  },
+  {
+   "default": "5",
+   "depends_on": "eval:doc.enable_backup_rotation",
+   "description": "Keep only this many most recent backups. Older backups will be deleted.",
+   "fieldname": "retention_count",
+   "fieldtype": "Int",
+   "label": "Retention Count",
+   "non_negative": 1
   }
  ],
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-15 12:17:49.167012",
+ "modified": "2026-07-09 23:52:17.739784",
  "modified_by": "Administrator",
  "module": "Offsite Backups",
  "name": "S3 Backup Settings",

--- a/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
@@ -257,7 +257,7 @@ def delete_old_backups_from_s3() -> int:
 			if len(folder_name) >= 15:
 				date_str = folder_name[:15]
 				try:
-					folder_date = datetime.strptime(date_str, "%Y%m%d_%H%M%S").date()
+					folder_date = datetime.strptime(date_str, "%Y%m%d_%H%M%S")
 					backup_folders.append((folder, folder_date))
 				except ValueError:
 					continue

--- a/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
@@ -205,7 +205,7 @@ def upload_file_to_s3(filename, folder, conn, bucket):
 
 
 def delete_s3_folder(conn, bucket, folder):
-	"""Delete all objects in a folder"""
+	"""Delete all objects in a folder, chunked to stay under AWS 1000-key limit."""
 	paginator = conn.get_paginator("list_objects_v2")
 	pages = paginator.paginate(Bucket=bucket, Prefix=folder)
 
@@ -214,8 +214,11 @@ def delete_s3_folder(conn, bucket, folder):
 		for obj in page.get("Contents", []):
 			objects_to_delete.append({"Key": obj["Key"]})
 
-	if objects_to_delete:
-		conn.delete_objects(Bucket=bucket, Delete={"Objects": objects_to_delete})
+	for i in range(0, len(objects_to_delete), 1000):
+		conn.delete_objects(
+			Bucket=bucket,
+			Delete={"Objects": objects_to_delete[i : i + 1000]},
+		)
 
 
 def delete_old_backups_from_s3() -> int:

--- a/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
@@ -204,16 +204,13 @@ def upload_file_to_s3(filename, folder, conn, bucket):
 	conn.upload_file(filename, bucket, destpath)  # Requires PutObject permission
 
 
-def delete_s3_folder(conn, bucket, folder) -> list:
+def delete_s3_folder(conn, bucket, folder):
 	"""Delete all objects in a folder, chunked to stay under AWS 1000-key limit.
 
 	Args:
 		conn (boto3.client): S3 client
 		bucket (str): S3 bucket
 		folder (str): S3 folder
-
-	Returns:
-		list: List of errors
 	"""
 	paginator = conn.get_paginator("list_objects_v2")
 	pages = paginator.paginate(Bucket=bucket, Prefix=folder)
@@ -231,7 +228,11 @@ def delete_s3_folder(conn, bucket, folder) -> list:
 		)
 		errors.extend(response.get("Errors", []))
 
-	return errors
+	for err in errors:
+		frappe.log_error(
+			title="S3 Backup Rotation Delete Error",
+			message=f"Failed to delete {err['Key']}: {err['Code']} - {err['Message']}",
+		)
 
 
 def delete_old_backups_from_s3() -> int:
@@ -285,17 +286,7 @@ def delete_old_backups_from_s3() -> int:
 	folders_to_delete = backup_folders[doc.retention_count :]
 
 	# Delete old backups
-	all_errors = []
 	for folder, __ in folders_to_delete:
-		errors = delete_s3_folder(conn, bucket, folder)
-		all_errors.extend(errors)
-
-	if all_errors:
-		failed_keys = [e["Key"] for e in all_errors]
-		frappe.throw(
-			_("Failed to delete {0} backup object(s) from S3: {1}").format(
-				len(failed_keys), ", ".join(failed_keys[:10])
-			)
-		)
+		delete_s3_folder(conn, bucket, folder)
 
 	return len(folders_to_delete)

--- a/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 import os
 import os.path
+from datetime import datetime
 
 import boto3
 import frappe
@@ -33,10 +34,12 @@ class S3BackupSettings(Document):
 		backup_files: DF.Check
 		backup_path: DF.Data | None
 		bucket: DF.Data
+		enable_backup_rotation: DF.Check
 		enabled: DF.Check
 		endpoint_url: DF.Data | None
 		frequency: DF.Literal["Daily", "Weekly", "Monthly", "None"]
 		notify_email: DF.Data
+		retention_count: DF.Int
 		secret_access_key: DF.Password
 		send_email_for_successful_backup: DF.Check
 	# end: auto-generated types
@@ -50,6 +53,10 @@ class S3BackupSettings(Document):
 
 		if self.backup_path and self.backup_path[-1] != "/":
 			self.backup_path += "/"
+
+		if self.enable_backup_rotation:
+			if not self.retention_count or self.retention_count < 1:
+				frappe.throw(_("Number of Backups to Keep must be at least 1"))
 
 		conn = boto3.client(
 			"s3",
@@ -109,6 +116,7 @@ def take_backups_s3(retry_count=0):
 	try:
 		validate_file_size()
 		backup_to_s3()
+		delete_old_backups_from_s3()
 		send_email(True, "Amazon S3", "S3 Backup Settings", "notify_email")
 	except JobTimeoutException:
 		if retry_count < 2:
@@ -194,3 +202,73 @@ def upload_file_to_s3(filename, folder, conn, bucket):
 	destpath = os.path.join(folder, os.path.basename(filename))
 	print("Uploading file:", filename)
 	conn.upload_file(filename, bucket, destpath)  # Requires PutObject permission
+
+
+def delete_s3_folder(conn, bucket, folder):
+	"""Delete all objects in a folder"""
+	paginator = conn.get_paginator("list_objects_v2")
+	pages = paginator.paginate(Bucket=bucket, Prefix=folder)
+
+	objects_to_delete = []
+	for page in pages:
+		for obj in page.get("Contents", []):
+			objects_to_delete.append({"Key": obj["Key"]})
+
+	if objects_to_delete:
+		conn.delete_objects(Bucket=bucket, Delete={"Objects": objects_to_delete})
+
+
+def delete_old_backups_from_s3() -> int:
+	"""Delete backups from S3 bucket based on rotation settings
+
+	Returns:
+		int: Number of backups deleted
+	"""
+	doc: S3BackupSettings = frappe.get_single("S3 Backup Settings")  # type: ignore
+
+	if not doc.enabled or not doc.enable_backup_rotation or not doc.retention_count:
+		return 0
+
+	conn = boto3.client(
+		"s3",
+		aws_access_key_id=doc.access_key_id,
+		aws_secret_access_key=doc.get_password("secret_access_key"),
+		endpoint_url=doc.endpoint_url or "https://s3.amazonaws.com",
+	)
+
+	bucket = doc.bucket
+	path = doc.backup_path or ""
+
+	# List all backup folders
+	paginator = conn.get_paginator("list_objects_v2")
+	pages = paginator.paginate(Bucket=bucket, Prefix=path, Delimiter="/")
+
+	backup_folders = []
+	for page in pages:
+		for prefix in page.get("CommonPrefixes", []):
+			folder = prefix["Prefix"]
+
+			# Extract date from folder name (format: YYYYMMDD_HHMMSS/)
+			# The folder name is 15 chars + trailing slash
+			if len(folder) >= 15:
+				date_str = folder[:15]
+				try:
+					folder_date = datetime.strptime(date_str, "%Y%m%d_%H%M%S").date()
+					backup_folders.append((folder, folder_date))
+				except ValueError:
+					continue
+
+	# Sort by date descending (newest first)
+	backup_folders.sort(key=lambda x: x[1], reverse=True)
+
+	# Keep only the most recent backups
+	if len(backup_folders) <= doc.retention_count:
+		return 0
+
+	folders_to_delete = backup_folders[doc.retention_count :]
+
+	# Delete old backups
+	for folder, __ in folders_to_delete:
+		delete_s3_folder(conn, bucket, folder)
+
+	return len(folders_to_delete)

--- a/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
@@ -214,11 +214,15 @@ def delete_s3_folder(conn, bucket, folder):
 		for obj in page.get("Contents", []):
 			objects_to_delete.append({"Key": obj["Key"]})
 
+	errors = []
 	for i in range(0, len(objects_to_delete), 1000):
-		conn.delete_objects(
+		response = conn.delete_objects(
 			Bucket=bucket,
 			Delete={"Objects": objects_to_delete[i : i + 1000]},
 		)
+		errors.extend(response.get("Errors", []))
+
+	return errors
 
 
 def delete_old_backups_from_s3() -> int:
@@ -272,7 +276,17 @@ def delete_old_backups_from_s3() -> int:
 	folders_to_delete = backup_folders[doc.retention_count :]
 
 	# Delete old backups
+	all_errors = []
 	for folder, __ in folders_to_delete:
-		delete_s3_folder(conn, bucket, folder)
+		errors = delete_s3_folder(conn, bucket, folder)
+		all_errors.extend(errors)
+
+	if all_errors:
+		failed_keys = [e["Key"] for e in all_errors]
+		frappe.throw(
+			_("Failed to delete {0} backup object(s) from S3: {1}").format(
+				len(failed_keys), ", ".join(failed_keys[:10])
+			)
+		)
 
 	return len(folders_to_delete)

--- a/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
@@ -204,8 +204,17 @@ def upload_file_to_s3(filename, folder, conn, bucket):
 	conn.upload_file(filename, bucket, destpath)  # Requires PutObject permission
 
 
-def delete_s3_folder(conn, bucket, folder):
-	"""Delete all objects in a folder, chunked to stay under AWS 1000-key limit."""
+def delete_s3_folder(conn, bucket, folder) -> list:
+	"""Delete all objects in a folder, chunked to stay under AWS 1000-key limit.
+
+	Args:
+		conn (boto3.client): S3 client
+		bucket (str): S3 bucket
+		folder (str): S3 folder
+
+	Returns:
+		list: List of errors
+	"""
 	paginator = conn.get_paginator("list_objects_v2")
 	pages = paginator.paginate(Bucket=bucket, Prefix=folder)
 

--- a/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/offsite_backups/offsite_backups/doctype/s3_backup_settings/s3_backup_settings.py
@@ -247,11 +247,12 @@ def delete_old_backups_from_s3() -> int:
 	for page in pages:
 		for prefix in page.get("CommonPrefixes", []):
 			folder = prefix["Prefix"]
+			folder_name = folder[len(path) :]
 
 			# Extract date from folder name (format: YYYYMMDD_HHMMSS/)
 			# The folder name is 15 chars + trailing slash
-			if len(folder) >= 15:
-				date_str = folder[:15]
+			if len(folder_name) >= 15:
+				date_str = folder_name[:15]
 				try:
 					folder_date = datetime.strptime(date_str, "%Y%m%d_%H%M%S").date()
 					backup_folders.append((folder, folder_date))


### PR DESCRIPTION
## Summary

Add a backup rotation feature to S3 Backup Settings that automatically deletes old backup folders from the S3 bucket after each successful upload, preventing unbounded storage growth.

## Type of Change

- feat: New feature

## Changes

- feat(s3-backup-settings): Add `enable_backup_rotation` and `retention_count` fields to the S3 Backup Settings DocType, allowing users to configure how many backup folders to keep.
- feat(s3-backup-settings): Implement `delete_old_backups_from_s3()` to list all backup folders in the S3 bucket, sort them by date (parsed from the YYYYMMDD_HHMMSS folder name), and delete the oldest folders that exceed the retention count.
- feat(s3-backup-settings): Add `delete_s3_folder()` helper to remove all objects within a given S3 folder prefix using paginated listing and batch `delete_objects`.
- feat(s3-backup-settings): Integrate rotation into the backup flow by calling `delete_old_backups_from_s3()` after each `successful backup_to_s3()`.
- feat(s3-backup-settings): Add validation that `retention_count` is at least 1 when rotation is enabled.

## Breaking Changes
None.

## Related Issues

closes #19

## Testing

- Verified that with rotation enabled, only the configured number of backup folders are retained after backup.
- Verified that rotation is skipped when disabled or retention_count is not set.
- Verified that folders with non-matching naming patterns are safely skipped.