### PR TITLE
fix: upgrade boto3 and pin cryptography/pyopenssl for Python 3.14 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
-    "boto3>=1.35.0",
-    "cryptography>=42.0.0",
-    "pyopenssl>=24.0.0",
+    "boto3~=1.35.0",
+    "cryptography~=42.0.0",
+    "pyopenssl~=24.0.0",
     "dropbox~=12.0.2",
     "google-api-python-client~=2.172.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
-    "boto3~=1.34.143",
+    "boto3>=1.35.0",
+    "cryptography>=42.0.0",
+    "pyopenssl>=24.0.0",
     "dropbox~=12.0.2",
     "google-api-python-client~=2.172.0"
 ]


### PR DESCRIPTION
## Problem

On Python 3.14, importing `s3_backup_settings` crashes at startup with:

AttributeError: module 'lib' has no attribute 'GEN_EMAIL'


The failure chain is:

`boto3~=1.34.143` → `botocore.httpsession` → `urllib3.contrib.pyopenssl` → `OpenSSL.crypto` → crash

The `GEN_EMAIL` constant was removed in `cryptography` 42.x. The old pinned `boto3` version pulls in an older `botocore` that unconditionally imports `urllib3.contrib.pyopenssl`, which in turn loads `pyopenssl` — and any installed `pyopenssl` built against the old `cryptography` ABI fails to initialise.

This makes the entire site **unable to boot** on Python 3.14, since Frappe loads doctype controllers during the session boot sequence.

## Changes

- `boto3~=1.34.143` → `boto3>=1.35.0` — `botocore` 1.35+ targets `urllib3` 2.x, which removed the `pyopenssl` contrib module entirely, cutting the import chain at its root.
- Added `cryptography>=42.0.0` — ensures the `cryptography` library is new enough that `pyopenssl` can initialise correctly even if it ends up installed as a transitive dependency.
- Added `pyopenssl>=24.0.0` — the first release series compatible with `cryptography` 42.x.

## Testing

Verified by deploying to a Frappe Cloud site running Python 3.14 — site boots and the S3 Backup Settings doctype loads without error.